### PR TITLE
Atom-shell renamed

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
         </li>
         <li>
           <strong>What is Vessel written in?</strong>
-          <p>Vessel is built using <a href="https://github.com/atom/atom-shell">Atom-Shell</a>, the core of GitHub's <a href="https://atom.io">Atom</a> editor and is written primarily in CoffeeScript.</p>
+          <p>Vessel is built using <a href="https://github.com/atom/electron">Electron</a>, the core of GitHub's <a href="https://atom.io">Atom</a> editor and is written primarily in CoffeeScript.</p>
         </li>
         <li>
           <strong>Can I contribute to Vessel?</strong>


### PR DESCRIPTION
Atom-shell is now called Electron, just a small pull request to be up to date.
